### PR TITLE
Resend admin invite links

### DIFF
--- a/models/activityLog.ts
+++ b/models/activityLog.ts
@@ -36,6 +36,7 @@ const ActivityLogSchema: Schema = new Schema(
         'LOGIN_FAILED',
         'LOGOUT',
         'ADMIN_INVITED',
+        'ADMIN_INVITE_RESENT',
         'ADMIN_REMOVED',
         'PASSWORD_RESET',
         'PASSWORD_RESET_INITIATED',

--- a/public/js/admin-management.js
+++ b/public/js/admin-management.js
@@ -74,13 +74,23 @@ document.addEventListener('DOMContentLoaded', function() {
                 const btnGroup = document.createElement('div');
                 btnGroup.className = 'btn-group btn-group-sm';
                 
-                // Reset password button
-                const resetBtn = document.createElement('button');
-                resetBtn.className = 'btn btn-outline-warning';
-                resetBtn.innerHTML = '<i class="bi bi-key"></i> Reset';
-                resetBtn.title = 'Send password reset link';
-                resetBtn.addEventListener('click', () => resetPassword(admin._id));
-                btnGroup.appendChild(resetBtn);
+                // Re-send invite button (only if setup is pending)
+                if (admin.needsPasswordSetup) {
+                    const resendBtn = document.createElement('button');
+                    resendBtn.className = 'btn btn-outline-warning';
+                    resendBtn.innerHTML = '<i class="bi bi-envelope"></i> Re-send Invite';
+                    resendBtn.title = 'Re-send invitation email';
+                    resendBtn.addEventListener('click', () => resendInvite(admin._id));
+                    btnGroup.appendChild(resendBtn);
+                } else {
+                    // Reset password button (only if setup is complete)
+                    const resetBtn = document.createElement('button');
+                    resetBtn.className = 'btn btn-outline-warning';
+                    resetBtn.innerHTML = '<i class="bi bi-key"></i> Reset';
+                    resetBtn.title = 'Send password reset link';
+                    resetBtn.addEventListener('click', () => resetPassword(admin._id));
+                    btnGroup.appendChild(resetBtn);
+                }
                 
                 // Unlock button (only if locked)
                 if (admin.isLocked) {
@@ -249,6 +259,49 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     };
 
+    // Re-send invite
+    window.resendInvite = async function(adminId) {
+        if (!confirm('Are you sure you want to re-send the invitation email to this admin?')) return;
+        
+        try {
+            const response = await fetch('/admin/admins/resend-invite/' + adminId, {
+                method: 'POST'
+            });
+            
+            if (response.ok) {
+                const alert = document.createElement('div');
+                alert.className = 'alert alert-success alert-dismissible fade show position-fixed';
+                alert.style.cssText = 'top: 20px; right: 20px; z-index: 9999; min-width: 350px;';
+                alert.innerHTML = `
+                    <div class="d-flex align-items-start">
+                        <i class="bi bi-check-circle-fill me-2 mt-1"></i>
+                        <div>
+                            <strong>Invitation Re-sent!</strong>
+                            <p class="mb-0 small">A secure password setup link has been re-sent to the admin's email. The link expires in 24 hours.</p>
+                        </div>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                    </div>
+                `;
+                document.body.appendChild(alert);
+                
+                // Auto-remove after 6 seconds
+                setTimeout(() => {
+                    if (alert.parentNode) {
+                        alert.parentNode.removeChild(alert);
+                    }
+                }, 6000);
+                
+                loadAdmins();
+            } else {
+                const data = await response.json();
+                alert('Failed to re-send invitation: ' + (data.error || 'Unknown error'));
+            }
+        } catch (error) {
+            alert('Failed to re-send invitation');
+        }
+    };
+
+    // Unlock Account
     window.unlockAccount = async function(adminId) {
         if (!confirm('Are you sure you want to unlock this account?')) return;
         

--- a/routes/admin.ts
+++ b/routes/admin.ts
@@ -88,6 +88,60 @@ router.post('/invite', requireAuth, [
   }
 });
 
+// Re-send admin invite
+router.post('/resend-invite/:adminId', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const { adminId } = req.params;
+    const resendingAdmin = req.admin!;
+
+    // Find the admin
+    const targetAdmin = await Admin.findById(adminId);
+    if (!targetAdmin) {
+      return res.status(404).json({ error: 'Admin not found' });
+    }
+
+    // Check if the admin has already set up their password
+    if (!targetAdmin.needsPasswordSetup) {
+      return res.status(400).json({ error: 'This admin has already set up their password' });
+    }
+
+    // Generate new password setup token
+    const setupToken = targetAdmin.generatePasswordSetupToken();
+    await targetAdmin.save();
+
+    // Send password setup email
+    try {
+      await sendPasswordSetupEmail(targetAdmin.email, setupToken, true);
+    } catch (emailError) {
+      console.error('Failed to send password setup email:', emailError);
+      return res.status(500).json({ error: 'Failed to send invitation email. Please try again.' });
+    }
+
+    // Log activity
+    await logActivity({
+      adminId: resendingAdmin._id,
+      adminEmail: resendingAdmin.email,
+      action: 'ADMIN_INVITE_RESENT',
+      details: `Re-sent admin invite to: ${targetAdmin.email}`,
+      targetAdminId: targetAdmin._id,
+      targetAdminEmail: targetAdmin.email,
+      success: true,
+      req
+    });
+
+    res.json({
+      message: 'Admin invitation re-sent successfully',
+      admin: {
+        id: targetAdmin._id,
+        email: targetAdmin.email
+      }
+    });
+  } catch (error) {
+    console.error('Resend invite error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // Remove admin
 router.delete('/:adminId', requireAuth, async (req: Request, res: Response) => {
   try {


### PR DESCRIPTION
Add the ability to re-send admin invite links for accounts that have not yet completed password setup.

---

[Slack Thread](https://mobyinc.slack.com/archives/D092X5QU67J/p1753465226368569?thread_ts=1753465226.368569&cid=D092X5QU67J) • [Open in Web](https://cursor.com/agents?id=bc-85754ffa-262a-4fe9-a289-525fda338b28) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-85754ffa-262a-4fe9-a289-525fda338b28)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for admins to re-send invitation emails to other admins who have not yet set up their password. A "Re-send Invite" button will appear for these users in the admin management interface.
  * Introduced a new route to handle re-sending admin invite emails, with appropriate success and error notifications.

* **Bug Fixes**
  * Improved feedback and error handling when re-sending admin invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->